### PR TITLE
add aws cli support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN apk add make
 
 RUN pip3 install azure-cli==2.8.0
 
+# aws cli
+RUN pip3 install awscli==1.18.106
+
 COPY --from=builder /data/kubectl /usr/local/bin
 COPY --from=builder /data/skaffold /usr/local/bin
 COPY --from=builder /data/helm /usr/local/bin


### PR DESCRIPTION
The reason for installing version one.
Pulumi official image also use version one so version one should be good enough. 
https://github.com/aws/aws-cli/issues/4947